### PR TITLE
[MISC] Reorder translations and remove useless ones

### DIFF
--- a/application-analytics-ui/src/main/resources/Analytics/Code/AnalyticsTranslations.xml
+++ b/application-analytics-ui/src/main/resources/Analytics/Code/AnalyticsTranslations.xml
@@ -36,117 +36,100 @@
   <minorEdit>false</minorEdit>
   <syntaxId>plain/1.0</syntaxId>
   <hidden>true</hidden>
-  <content>## Class fields
-Analytics.Code.AnalyticsDashboardClass_description.hint=Additional information to be displayed.
-Analytics.Code.AnalyticsDashboardClass_description=Description
-Analytics.Code.AnalyticsDashboardClass_displayedStatistics=Displayed statistics
-Analytics.Code.AnalyticsDashboardClass_endDate=End date
-Analytics.Code.AnalyticsDashboardClass_endDate.hint=End time of the date interval used on all statistics of this dashboard.
-Analytics.Code.AnalyticsDashboardClass_DisplayedStatistics.hint=List of statistics widgets that will be displayed in the current dashboard, in order.
-Analytics.Code.AnalyticsDashboardClass_startDate=Start date
-Analytics.Code.AnalyticsDashboardClass_startDate.hint=Start time of the date interval used on all statistics of this dashboard.
-
-## Most Viewed Pages Macro
+  <content>## Most Viewed Pages Macro
 analytics.mostViewedPages.header.actions=Actions
 analytics.mostViewedPages.header.bounceRate=Bounce rate
 analytics.mostViewedPages.header.date=Date
-analytics.mostViewedPages.header.entryNbActions= No. of actions
 analytics.mostViewedPages.header.emptyvalue=-
+analytics.mostViewedPages.header.entryNbActions=No. of actions
 analytics.mostViewedPages.header.exitRate=Exit rate
 analytics.mostViewedPages.header.hits=Page views
-analytics.mostViewedPages.header.timeSpent=Time spent(s)
 analytics.mostViewedPages.header.pageTitle=Page title
+analytics.mostViewedPages.header.timeSpent=Time spent(s)
 analytics.mostViewedPages.header.visits=Unique visitors
 analytics.mostViewedPages.header.year=Year
-analytics.mostViewedPages.parameter.label.startDate=Start time of the date interval used for this macro
 analytics.mostViewedPages.parameter.label.endDate=End time of the date interval used for this macro
+analytics.mostViewedPages.parameter.label.startDate=Start time of the date interval used for this macro
 rendering.macro.mostViewedPages.name=Most viewed pages
 
 ## Pages following a site search
+analytics.PagesFollowingASiteSearchJSON.header.actions=Actions
+analytics.PagesFollowingASiteSearchJSON.header.clicked=Clicked in search results
 analytics.PagesFollowingASiteSearchJSON.header.date=Date
 analytics.PagesFollowingASiteSearchJSON.header.destinationPage=Destination page
-analytics.PagesFollowingASiteSearchJSON.header.clicked=Clicked in search results
-analytics.PagesFollowingASiteSearchJSON.header.pageViews=Views
 analytics.PagesFollowingASiteSearchJSON.header.loadTime=Avg. load time
-analytics.PagesFollowingASiteSearchJSON.header.actions=Actions
+analytics.PagesFollowingASiteSearchJSON.header.pageViews=Views
 
 ## Row Evolution
-analytics.rowEvolution.modal.label=Row Evolution
 analytics.rowEvolution.modal.close=Close
-analytics.rowEvolution.modal.period=Period
-analytics.rowEvolution.modal.field=Field
-analytics.rowEvolution.modal.periodLength=Period length
 analytics.rowEvolution.modal.day.label=Day
-analytics.rowEvolution.modal.week.label=Week
-analytics.rowEvolution.modal.month.label=Month
-analytics.rowEvolution.modal.year.label=Year
-analytics.rowEvolution.modal.field.pageViews=Page views
-analytics.rowEvolution.modal.field.uniqueViews=Unique views
 analytics.rowEvolution.modal.field.avgTime=Time spent on page
-analytics.rowEvolution.modal.field.searches=Searches
+analytics.rowEvolution.modal.field.pageViews=Page views
 analytics.rowEvolution.modal.field.searchResultPages=Search result pages
+analytics.rowEvolution.modal.field.searches=Searches
+analytics.rowEvolution.modal.field.uniqueViews=Unique views
+analytics.rowEvolution.modal.field=Field
+analytics.rowEvolution.modal.label=Row Evolution
+analytics.rowEvolution.modal.month.label=Month
+analytics.rowEvolution.modal.period=Period
+analytics.rowEvolution.modal.periodLength=Period length
+analytics.rowEvolution.modal.week.label=Week
+analytics.rowEvolution.modal.year.label=Year
 
 ## Site Search Keywords Macro
+analytics.action.hover.rowEvolution=Row evolution
+analytics.rowEvolution.modal.field.clickedSearchResult=Clicked in search results
+analytics.rowEvolution.modal.field.searchResultsPages=Search result pages
+analytics.rowEvolution.modal.field.searches=Searches
 analytics.siteSearchKeywords.header.actions=Actions
 analytics.siteSearchKeywords.header.exitRate=Search exists(%)
 analytics.siteSearchKeywords.header.keyword=Keyword
 analytics.siteSearchKeywords.header.nbOfResultPages=Search results pages
 analytics.siteSearchKeywords.header.searches=Searches
-analytics.action.hover.rowEvolution=Row evolution
-analytics.rowEvolution.modal.field.clickedSearchResult=Clicked in search results
-analytics.rowEvolution.modal.field.searches=Searches
-analytics.rowEvolution.modal.field.searchResultsPages=Search result pages
 
 ## Search Categories
-analytics.searchCategories.header.title=Search category
-analytics.searchCategories.header.searches=Searches
-analytics.searchCategories.header.searchResultsPages=Search result pages
+analytics.rowEvolution.modal.field.actions=Actions
+analytics.rowEvolution.modal.field.avgTime=Avg. time spent
+analytics.rowEvolution.modal.field.bounceRate=Bounce rate
+analytics.rowEvolution.modal.field.clickedSearchResult=Clicked in search results
+analytics.rowEvolution.modal.field.conversionRate=Conversion rate
+analytics.rowEvolution.modal.field.timeSpent=Time spent
+analytics.rowEvolution.modal.field.visits=Visits
 analytics.searchCategories.header.actions=Actions
 analytics.searchCategories.header.category=Category
-analytics.rowEvolution.modal.field.avgTime=Avg. time spent
-analytics.rowEvolution.modal.field.clickedSearchResult=Clicked in search results
-analytics.rowEvolution.modal.field.visits=Visits
-analytics.rowEvolution.modal.field.actions=Actions
-analytics.rowEvolution.modal.field.timeSpent=Time spent
-analytics.rowEvolution.modal.field.bounceRate=Bounce rate
-analytics.rowEvolution.modal.field.conversionRate=Conversion rate
+analytics.searchCategories.header.searchResultsPages=Search result pages
+analytics.searchCategories.header.searches=Searches
+analytics.searchCategories.header.title=Search category
 
 ## Software/Devices Macros
 analytics.softwareDevices.header.actions=Actions
 analytics.softwareDevices.header.bounceRate=Bounce rate
-analytics.softwareDevices.header.engines=Browser engine
 analytics.softwareDevices.header.browser=Browser
-analytics.softwareDevices.header.deviceBrand=Brand
-analytics.softwareDevices.header.conversionRate=Conversion(%)
 analytics.softwareDevices.header.configurations=Configuration
+analytics.softwareDevices.header.conversionRate=Conversion(%)
+analytics.softwareDevices.header.deviceBrand=Brand
 analytics.softwareDevices.header.deviceModel=Device model
 analytics.softwareDevices.header.deviceType=Device type
-analytics.softwareDevices.header.osVersion=OS version
-analytics.softwareDevices.header.resolution=Resolution 
-analytics.softwareDevices.header.timeSpent=Time spent 
+analytics.softwareDevices.header.engines=Browser engine
 analytics.softwareDevices.header.nbOfActions=User actions
+analytics.softwareDevices.header.osVersion=OS version
+analytics.softwareDevices.header.resolution=Resolution
+analytics.softwareDevices.header.timeSpent=Time spent
 analytics.softwareDevices.header.visits=Visits
 
 ## Admin section
-admin.analytics.application=Analytics
-Analytics.Code.ConfigurationClass_authToken=Authentication token
 Analytics.Code.ConfigurationClass_authToken.hint=Token generated by Matomo to be capable of using the API to view the data. This token can be generated from Settings -&gt; Personal -&gt; Security -&gt; Create New Token
-Analytics.Code.ConfigurationClass_siteId=Site ID
-Analytics.Code.ConfigurationClass_siteId.hint=The ID of the site that you want to see the statistics for. This can be taken from Matomo server integration tab
-Analytics.Code.ConfigurationClass_requestAddress=Request address
+Analytics.Code.ConfigurationClass_authToken=Authentication token
 Analytics.Code.ConfigurationClass_requestAddress.hint=The Matomo URL. This can be taken from Matomo server integration tab.
-Analytics.Code.ConfigurationClass_trackingCode=Tracking code
+Analytics.Code.ConfigurationClass_requestAddress=Request address
+Analytics.Code.ConfigurationClass_siteId.hint=The ID of the site that you want to see the statistics for. This can be taken from Matomo server integration tab
+Analytics.Code.ConfigurationClass_siteId=Site ID
 Analytics.Code.ConfigurationClass_trackingCode.hint=Tracking Code received from Matomo. The 'u' variable might be different than the one that is initially generated by Matomo if the server you want to track is on another machine. To fix this, go to the integration tab, copy the Matomo URL, and replace the value of 'u' with the Matomo URL.
+Analytics.Code.ConfigurationClass_trackingCode=Tracking code
+admin.analytics.application=Analytics
 analytics.config.checkConnection.error=Failed to connect to Matomo. Please check your configuration values.
 analytics.config.checkConnection.loading=Checking connection to Matomo.
 analytics.config.checkConnection.success=Test connection succeeded!
-
-## Livetable keys
-analytics.livetable.emptyvalue=Not Defined
-analytics.livetable.endDate=End Date
-analytics.livetable.doc.name=Page Name
-analytics.livetable.doc.title=Page Title
-analytics.livetable.startDate=Start Date
 
 ## Livedata keys
 analytics.livedata.action.rowEvolution.title=Row Evolution
@@ -154,11 +137,11 @@ analytics.livedata.action.rowEvolution.title=Row Evolution
 ## Others
 analytics.extension.name=Analytics Application (Pro)
 analytics.extension.title=Analytics
-rendering.macro.analyticsFilter.startDate=Start date
-rendering.macro.analyticsFilter.endDate=End date
 rendering.macro.analyticsFilter.apply=Apply
-rendering.macro.analyticsFilter.name=Analytics filter
 rendering.macro.analyticsFilter.description=Add filtering options for the analytics macros of the current page. The filtering criteria will be saved in the current URL, to have a reproducible state, and will also override eventual filter set at macro level.</content>
+rendering.macro.analyticsFilter.endDate=End date
+rendering.macro.analyticsFilter.name=Analytics filter
+rendering.macro.analyticsFilter.startDate=Start date
   <object>
     <name>Analytics.Code.AnalyticsTranslations</name>
     <number>0</number>


### PR DESCRIPTION
Reorder the translations in alphabetical order. Remove the  ## Class fields'category and the ## livetable category, as both have been deleted from the code base.