### PR TITLE
 Add more options for the Row evolution chart #51

### DIFF
--- a/application-analytics-ui/src/main/resources/Analytics/Code/AnalyticsTranslations.xml
+++ b/application-analytics-ui/src/main/resources/Analytics/Code/AnalyticsTranslations.xml
@@ -61,6 +61,7 @@ analytics.PagesFollowingASiteSearchJSON.header.loadTime=Avg. load time
 analytics.PagesFollowingASiteSearchJSON.header.pageViews=Views
 
 ## Row Evolution
+
 analytics.rowEvolution.modal.close=Close
 analytics.rowEvolution.modal.day.label=Day
 analytics.rowEvolution.modal.field.actions=Actions

--- a/application-analytics-ui/src/main/resources/Analytics/Code/AnalyticsTranslations.xml
+++ b/application-analytics-ui/src/main/resources/Analytics/Code/AnalyticsTranslations.xml
@@ -61,7 +61,6 @@ analytics.PagesFollowingASiteSearchJSON.header.loadTime=Avg. load time
 analytics.PagesFollowingASiteSearchJSON.header.pageViews=Views
 
 ## Row Evolution
-
 analytics.rowEvolution.modal.close=Close
 analytics.rowEvolution.modal.day.label=Day
 analytics.rowEvolution.modal.field.actions=Actions

--- a/application-analytics-ui/src/main/resources/Analytics/Code/AnalyticsTranslations.xml
+++ b/application-analytics-ui/src/main/resources/Analytics/Code/AnalyticsTranslations.xml
@@ -61,13 +61,21 @@ analytics.PagesFollowingASiteSearchJSON.header.loadTime=Avg. load time
 analytics.PagesFollowingASiteSearchJSON.header.pageViews=Views
 
 ## Row Evolution
+
 analytics.rowEvolution.modal.close=Close
 analytics.rowEvolution.modal.day.label=Day
+analytics.rowEvolution.modal.field.actions=Actions
 analytics.rowEvolution.modal.field.avgTime=Time spent on page
+analytics.rowEvolution.modal.field.bounceRate=Bounce rate(%)
+analytics.rowEvolution.modal.field.clickedSearchResult=Clicked in search results
+analytics.rowEvolution.modal.field.conversionRate=Conversion rate
+analytics.rowEvolution.modal.field.exitRate=Exit rate(%)
 analytics.rowEvolution.modal.field.pageViews=Page views
 analytics.rowEvolution.modal.field.searchResultPages=Search result pages
 analytics.rowEvolution.modal.field.searches=Searches
+analytics.rowEvolution.modal.field.timeSpent=Time spent
 analytics.rowEvolution.modal.field.uniqueViews=Unique views
+analytics.rowEvolution.modal.field.visits=Visits
 analytics.rowEvolution.modal.field=Field
 analytics.rowEvolution.modal.label=Row Evolution
 analytics.rowEvolution.modal.month.label=Month
@@ -78,9 +86,6 @@ analytics.rowEvolution.modal.year.label=Year
 
 ## Site Search Keywords Macro
 analytics.action.hover.rowEvolution=Row evolution
-analytics.rowEvolution.modal.field.clickedSearchResult=Clicked in search results
-analytics.rowEvolution.modal.field.searchResultsPages=Search result pages
-analytics.rowEvolution.modal.field.searches=Searches
 analytics.siteSearchKeywords.header.actions=Actions
 analytics.siteSearchKeywords.header.exitRate=Search exists(%)
 analytics.siteSearchKeywords.header.keyword=Keyword
@@ -88,13 +93,6 @@ analytics.siteSearchKeywords.header.nbOfResultPages=Search results pages
 analytics.siteSearchKeywords.header.searches=Searches
 
 ## Search Categories
-analytics.rowEvolution.modal.field.actions=Actions
-analytics.rowEvolution.modal.field.avgTime=Avg. time spent
-analytics.rowEvolution.modal.field.bounceRate=Bounce rate
-analytics.rowEvolution.modal.field.clickedSearchResult=Clicked in search results
-analytics.rowEvolution.modal.field.conversionRate=Conversion rate
-analytics.rowEvolution.modal.field.timeSpent=Time spent
-analytics.rowEvolution.modal.field.visits=Visits
 analytics.searchCategories.header.actions=Actions
 analytics.searchCategories.header.category=Category
 analytics.searchCategories.header.searchResultsPages=Search result pages

--- a/application-analytics-ui/src/main/resources/Analytics/Code/Macros/Browsers.xml
+++ b/application-analytics-ui/src/main/resources/Analytics/Code/Macros/Browsers.xml
@@ -283,7 +283,7 @@
   #set ($rowEvolutionParams = {
     'visits': 'nb_visits',
     'actions': 'nb_actions',
-    'spentTime': 'sum_visit_length',
+    'timeSpent': 'sum_visit_length',
     'bounceRate': 'bounce_count'
   })
   #modalRowEvolution($rowEvolutionParams, 'Browsers', $macroId)

--- a/application-analytics-ui/src/main/resources/Analytics/Code/Macros/MostViewedPages.xml
+++ b/application-analytics-ui/src/main/resources/Analytics/Code/Macros/MostViewedPages.xml
@@ -285,7 +285,9 @@
   #set ($rowEvolutionParams = {
     'pageViews': 'nb_hits',
     'uniqueViews': 'nb_visits',
-    "avgTime": 'avg_time_on_page'
+    "avgTime": 'avg_time_on_page',
+    'bounceRate': 'bounce_rate',
+    'exitRate': 'exit_rate'
   })
   #modalRowEvolution($rowEvolutionParams, 'MostViewedPages', $macroId)
 #end

--- a/application-analytics-ui/src/main/resources/Analytics/Code/Macros/PagesFollowingASiteSearch.xml
+++ b/application-analytics-ui/src/main/resources/Analytics/Code/Macros/PagesFollowingASiteSearch.xml
@@ -279,7 +279,9 @@
 
   #set ($rowEvolutionParams = {
     'pageViews': 'nb_hits',
-    'clickedSearchResult': 'nb_hits_following_search'
+    'clickedSearchResult': 'nb_hits_following_search',
+    'bounceRate': 'bounce_rate',
+    'exitRate': 'exit_rate'
   })
   #modalRowEvolution($rowEvolutionParams, 'PagesFollowingASiteSearch', $macroId)
 #end

--- a/application-analytics-ui/src/main/resources/Analytics/Code/Macros/RowEvolution.xml
+++ b/application-analytics-ui/src/main/resources/Analytics/Code/Macros/RowEvolution.xml
@@ -146,20 +146,21 @@ require(['jquery', 'chart'], ($) =&gt; {
   let currentModal;
   let currentOptions;
   let currentLoadingAnimation;
-
-  function processValues(data, field)
-  {
-    let result = []
-    for(let i=0; i&lt;data.length; i++)
-    {
-      let currentItem =  data[i];
-      let currentValue = currentItem[field] || 0;
-      if(typeof currentValue === 'string' )
-      {
-        currentValue = parseFloat(currentValue.replace('%', ''))
-      }
-      result.push(currentValue)
+  /**
+  * Processes the data parameter and returns an array of numbers.
+  *
+  * @param data json with the dataset.
+  * @param field the field that will pe processed.
+  */
+  function processChartValues(data, field) {
+    let result = $.map(data, function(currentItem) {
+    let currentValue = currentItem[field] || 0;
+    if (typeof currentValue === 'string') {
+        currentValue = parseFloat(currentValue.replace('%', ''));
     }
+    return currentValue;
+    });
+
     return result;
   }
   /**
@@ -169,7 +170,7 @@ require(['jquery', 'chart'], ($) =&gt; {
    */
   const renderChart = (data) =&gt; {
     const dates = data.map(item =&gt; item.date);
-    const values = processValues(data, currentModal.find(SELECTORS.field).val())
+    const values = processChartValues(data, currentModal.find(SELECTORS.field).val())
     const ctx = currentModal.find(SELECTORS.chart);
     // I can't modify and exiting chart because chart.js caches data about the chart and it can display the old data in
     // some cases.

--- a/application-analytics-ui/src/main/resources/Analytics/Code/Macros/RowEvolution.xml
+++ b/application-analytics-ui/src/main/resources/Analytics/Code/Macros/RowEvolution.xml
@@ -154,7 +154,6 @@ require(['jquery', 'chart'], ($) =&gt; {
     {
       let currentItem =  data[i];
       let currentValue = currentItem[field] || 0;
-      // if the currentValue is a string that means that it co
       if(typeof currentValue === 'string' )
       {
         currentValue = parseFloat(currentValue.replace('%', ''))

--- a/application-analytics-ui/src/main/resources/Analytics/Code/Macros/RowEvolution.xml
+++ b/application-analytics-ui/src/main/resources/Analytics/Code/Macros/RowEvolution.xml
@@ -153,14 +153,13 @@ require(['jquery', 'chart'], ($) =&gt; {
   * @param field the field that will pe processed.
   */
   function processChartValues(data, field) {
-    let result = $.map(data, function(currentItem) {
-    let currentValue = currentItem[field] || 0;
-    if (typeof currentValue === 'string') {
-        currentValue = parseFloat(currentValue.replace('%', ''));
-    }
-    return currentValue;
+      let result = $.map(data, function(currentItem) {
+      let currentValue = currentItem[field] || 0;
+      if (typeof currentValue === 'string') {
+          currentValue = parseFloat(currentValue.replace('%', ''));
+      }
+      return currentValue;
     });
-
     return result;
   }
   /**

--- a/application-analytics-ui/src/main/resources/Analytics/Code/Macros/RowEvolution.xml
+++ b/application-analytics-ui/src/main/resources/Analytics/Code/Macros/RowEvolution.xml
@@ -170,7 +170,7 @@ require(['jquery', 'chart'], ($) =&gt; {
    */
   const renderChart = (data) =&gt; {
     const dates = data.map(item =&gt; item.date);
-    const values = processChartValues(data, currentModal.find(SELECTORS.field).val())
+    const values = processChartValues(data, currentModal.find(SELECTORS.field).val());
     const ctx = currentModal.find(SELECTORS.chart);
     // I can't modify and exiting chart because chart.js caches data about the chart and it can display the old data in
     // some cases.

--- a/application-analytics-ui/src/main/resources/Analytics/Code/Macros/RowEvolution.xml
+++ b/application-analytics-ui/src/main/resources/Analytics/Code/Macros/RowEvolution.xml
@@ -152,8 +152,8 @@ require(['jquery', 'chart'], ($) =&gt; {
     let result = []
     for(let i=0; i&lt;data.length; i++)
     {
-      currentItem =  data[i];
-      currentValue = currentItem[field] || 0;
+      let currentItem =  data[i];
+      let currentValue = currentItem[field] || 0;
       // if the currentValue is a string that means that it co
       if(typeof currentValue === 'string' )
       {

--- a/application-analytics-ui/src/main/resources/Analytics/Code/Macros/RowEvolution.xml
+++ b/application-analytics-ui/src/main/resources/Analytics/Code/Macros/RowEvolution.xml
@@ -153,7 +153,7 @@ require(['jquery', 'chart'], ($) =&gt; {
   * @param field the field that will pe processed.
   */
   function processChartValues(data, field) {
-      let result = $.map(data, function(currentItem) {
+    let result = $.map(data, function(currentItem) {
       let currentValue = currentItem[field] || 0;
       if (typeof currentValue === 'string') {
           currentValue = parseFloat(currentValue.replace('%', ''));

--- a/application-analytics-ui/src/main/resources/Analytics/Code/Macros/RowEvolution.xml
+++ b/application-analytics-ui/src/main/resources/Analytics/Code/Macros/RowEvolution.xml
@@ -147,6 +147,22 @@ require(['jquery', 'chart'], ($) =&gt; {
   let currentOptions;
   let currentLoadingAnimation;
 
+  function processValues(data, field)
+  {
+    let result = []
+    for(let i=0; i&lt;data.length; i++)
+    {
+      currentItem =  data[i];
+      currentValue = currentItem[field] || 0;
+      // if the currentValue is a string that means that it co
+      if(typeof currentValue === 'string' )
+      {
+        currentValue = parseFloat(currentValue.replace('%', ''))
+      }
+      result.push(currentValue)
+    }
+    return result;
+  }
   /**
    * Creates the chart for displaying the data.
    *
@@ -154,7 +170,7 @@ require(['jquery', 'chart'], ($) =&gt; {
    */
   const renderChart = (data) =&gt; {
     const dates = data.map(item =&gt; item.date);
-    const field = data.map(item =&gt; item[currentModal.find(SELECTORS.field).val()] || 0);
+    const values = processValues(data, currentModal.find(SELECTORS.field).val())
     const ctx = currentModal.find(SELECTORS.chart);
     // I can't modify and exiting chart because chart.js caches data about the chart and it can display the old data in
     // some cases.
@@ -167,7 +183,7 @@ require(['jquery', 'chart'], ($) =&gt; {
         labels: dates,
         datasets: [{
           label: '',
-          data: field,
+          data: values,
           borderColor: currentOptions.data('color'),
           fill: false
         }]
@@ -282,8 +298,7 @@ require(['jquery', 'chart'], ($) =&gt; {
     displayPeriodDurations(period);
     fetchChartData(currentOptions.data('rowIdentifier'));
   });
-});
-</code>
+});</code>
     </property>
     <property>
       <name/>

--- a/application-analytics-ui/src/main/resources/Analytics/Code/Macros/SearchCategories.xml
+++ b/application-analytics-ui/src/main/resources/Analytics/Code/Macros/SearchCategories.xml
@@ -277,7 +277,7 @@
 
   #set ($rowEvolutionParams = {
     'searches': 'nb_visits',
-    'searchResultsPages': 'nb_pages_per_search'
+    'searchResultPages': 'nb_pages_per_search'
   })
   #modalRowEvolution($rowEvolutionParams, 'SearchCategories', $macroId)
 #end

--- a/application-analytics-ui/src/main/resources/Analytics/Code/Macros/SiteSearchKeywords.xml
+++ b/application-analytics-ui/src/main/resources/Analytics/Code/Macros/SiteSearchKeywords.xml
@@ -281,7 +281,8 @@
 
   #set ($rowEvolutionParams = {
     'searches': 'nb_visits',
-    'searchResultPages': 'nb_pages_per_search'
+    'searchResultPages': 'nb_pages_per_search',
+    'exitRate': 'exit_rate'
   })
   #modalRowEvolution($rowEvolutionParams, 'SiteSearchKeyword' $macroId)
 #end


### PR DESCRIPTION
Improved Row Evolution to support fields that contain % and added the bounce rate and exit rate fields to all the macros that support it. I also removed duplicated translation keys.
Preview:
![image](https://github.com/xwikisas/application-analytics/assets/92780090/36df0acb-4daf-4546-9932-cefc5a7647bd)
