### PR TITLE
Normal pages have N/A* in the No of actions #77

### DIFF
--- a/application-analytics-ui/src/main/resources/Analytics/Code/Macros/MostViewedPages.xml
+++ b/application-analytics-ui/src/main/resources/Analytics/Code/Macros/MostViewedPages.xml
@@ -275,7 +275,6 @@
         {'id': 'visits', 'displayer': 'html'},
         {'id': 'hits', 'displayer': 'html'},
         {'id': 'timeSpent', 'displayer': 'html'},
-        {'id': 'entryNbActions', 'displayer': 'html'},
         {'id': 'bounceRate', 'displayer': 'html'},
         {'id': 'exitRate', 'displayer': 'html'},
         {'id': 'actions', 'filterable': false, 'sortable': false, 'displayer': 'html'}
@@ -289,7 +288,7 @@
 
   {{liveData
     id="$macroId"
-    properties="pageTitle, visits, hits, timeSpent, entryNbActions, bounceRate, exitRate, actions"
+    properties="pageTitle, visits, hits, timeSpent, bounceRate, exitRate, actions"
     source='liveTable'
     sourceParameters="$parameters"
     sort='hits:desc'

--- a/application-analytics-ui/src/main/resources/Analytics/Code/Macros/MostViewedPagesJSON.xml
+++ b/application-analytics-ui/src/main/resources/Analytics/Code/Macros/MostViewedPagesJSON.xml
@@ -47,7 +47,6 @@
     'visits': 'nb_visits',
     'hits' : 'nb_hits',
     'timeSpent' : 'sum_time_spent',
-    'entryNbActions' : 'entry_nb_actions',
     'bounceRate' : 'bounce_rate',
     'exitRate' : 'exit_rate'
   })
@@ -94,7 +93,6 @@
       'visits' :  $currentEntry.get('nb_visits').asText(),
       'hits' : $currentEntry.get('nb_hits').asText(),
       'timeSpent' : $time,
-      'entryNbActions' : $currentEntry.get('entry_nb_actions').asText(),
       'bounceRate' : $currentEntry.get('bounce_rate').asText(),
       'exitRate' : $currentEntry.get('exit_rate').asText(),
       'actions' : "#analytics_actions($url)"


### PR DESCRIPTION
The issue is caused by the endpoint which doesn't return the column for all the pages. I've talked with Stefana to remove the column for this milestone and investigate further in the next milestone.