### PR TITLE
Added a try catch to make sure that the app doesn't die 

### DIFF
--- a/application-analytics-default/src/main/java/com/xwiki/analytics/internal/MostViewedJsonNormaliser.java
+++ b/application-analytics-default/src/main/java/com/xwiki/analytics/internal/MostViewedJsonNormaliser.java
@@ -71,15 +71,19 @@ public class MostViewedJsonNormaliser extends AbstractJsonNormaliser
     @Override
     protected JsonNode processNode(JsonNode currentNode, Map<String, String> extraValues)
     {
-        if (!currentNode.has(URL)) {
+        try {
+            if (!currentNode.has(URL)) {
+                return currentNode;
+            }
+            EntityReference pageReference = getPageReferenceFromUrl((ObjectNode) currentNode);
+            if (pageReference == null) {
+                return null;
+            }
+            updateNodeLabel((ObjectNode) currentNode, pageReference);
+            return currentNode;
+        } catch (Exception e) {
             return currentNode;
         }
-        EntityReference pageReference = getPageReferenceFromUrl((ObjectNode) currentNode);
-        if (pageReference == null) {
-            return null;
-        }
-        updateNodeLabel((ObjectNode) currentNode, pageReference);
-        return currentNode;
     }
 
     /**

--- a/application-analytics-default/src/main/java/com/xwiki/analytics/internal/MostViewedJsonNormaliser.java
+++ b/application-analytics-default/src/main/java/com/xwiki/analytics/internal/MostViewedJsonNormaliser.java
@@ -71,6 +71,9 @@ public class MostViewedJsonNormaliser extends AbstractJsonNormaliser
     @Override
     protected JsonNode processNode(JsonNode currentNode, Map<String, String> extraValues)
     {
+        // The try-catch is needed because the resolver can throw a very generic error, and if it isn't caught, the
+        // app will fail. We also return the currentNode without modifications because we want to display all
+        // the entries inside the UI.
         try {
             if (!currentNode.has(URL)) {
                 return currentNode;


### PR DESCRIPTION
Right now, the app will fail if the resolver throws an error. I've added a try-catch block to make sure that in the case of an error, the app doesn't fail, and the entry is still displayed inside the app.